### PR TITLE
Convert to ISO-8601 with T seperator & no ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ rust-g is build with [Rust] as you might have guessed from the name. Install rus
 
     cargo build --release
 
+If you are on a 64 bit machine, this will produce a 64 bit binary - BYOND can't run this.
+To avoid that, you should instead use
+
+	rustup target add i686-pc-windows-msvc
+
+followed by
+
+	cargo build --target=i686-pc-windows-msvc --release
+
 All dependencies will automatically be downloaded and compiled. rust-g should be compilable on
 both Rust stable and nightly.
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -30,7 +30,7 @@ byond_fn! { log_close_all()! {
 } }
 
 fn format(data: &str) -> String {
-    format!("[{}] {}\n", Utc::now().format("%F %T%.3f"), data)
+    format!("[{}] {}\n", Utc::now().format("%FT%T"), data)
 }
 
 fn write(path: &str, data: String) -> Result<usize> {


### PR DESCRIPTION
Also updates the README to show how to actually compile 32 bit binaries
on 64 bit windows